### PR TITLE
FEATURE: Terminate zip- and join-operations as quick as possible

### DIFF
--- a/src/main/kotlin/io/timvanoijen/github/kotlin/sortedsequence/SortedKeyValueSequence.kt
+++ b/src/main/kotlin/io/timvanoijen/github/kotlin/sortedsequence/SortedKeyValueSequence.kt
@@ -516,7 +516,13 @@ class SortedKeyValueSequence<TKey : Comparable<TKey>, out TValue> internal const
 
             var el1 = iterator1.nextOrNull()
             var el2 = iterator2.nextOrNull()
-            while (el1 != null || el2 != null) {
+            while (
+                when (joinType) {
+                    FULL_OUTER_JOIN -> el1 != null || el2 != null
+                    INNER_JOIN -> el1 != null && el2 != null
+                    LEFT_OUTER_JOIN -> el1 != null
+                    RIGHT_OUTER_JOIN -> el2 != null
+                }) {
                 val pair = when {
                     el1 == null -> null to el2
                     el2 == null -> el1 to null

--- a/src/test/kotlin/io/timvanoijen/github/kotlin/sortedsequence/SortedSequenceTest.kt
+++ b/src/test/kotlin/io/timvanoijen/github/kotlin/sortedsequence/SortedSequenceTest.kt
@@ -100,6 +100,19 @@ class SortedSequenceTest {
     }
 
     @Test
+    fun `zip terminates early when one sequence is empty`() {
+        val seqInfinite = generateSequence(1) { it + 1 }.assertSorted()
+        val seqFinite = seqInfinite.take(2).assertSorted()
+
+        val expected = listOf(1 to 1, 2 to 2)
+
+        assertEquals(expected, seqInfinite.innerZipByKey(seqFinite).toList())
+        assertEquals(expected, seqFinite.innerZipByKey(seqFinite).toList())
+        assertEquals(expected, seqInfinite.rightOuterZipByKey(seqFinite).toList())
+        assertEquals(expected, seqFinite.leftOuterZipByKey(seqInfinite).toList())
+    }
+
+    @Test
     fun `join operations work correctly`() {
         val seq1 = sequenceOf("1a", "2b", "2c").assertSortedBy { it.first() }
         val seq2 = sequenceOf("2x", "2y", "3z").assertSortedBy { it.first() }
@@ -195,6 +208,19 @@ class SortedSequenceTest {
             ),
             result9.toList()
         )
+    }
+
+    @Test
+    fun `join terminates early when one sequence is empty`() {
+        val seqInfinite = generateSequence(1) { it + 1 }.assertSorted()
+        val seqFinite = seqInfinite.take(2).assertSorted()
+
+        val expected = listOf(1 to 1, 2 to 2)
+
+        assertEquals(expected, seqInfinite.innerJoinByKey(seqFinite).toList())
+        assertEquals(expected, seqFinite.innerJoinByKey(seqFinite).toList())
+        assertEquals(expected, seqInfinite.rightOuterZipByKey(seqFinite).toList())
+        assertEquals(expected, seqFinite.leftOuterZipByKey(seqInfinite).toList())
     }
 
     @Test


### PR DESCRIPTION
Terminate zip- and join-operations as soon as one of the sequences finalizes and the joinType guarantees that no more elements will be produced anymore.